### PR TITLE
fix: ref passing to UIResourceRenderer

### DIFF
--- a/packages/client/src/components/UIResourceRenderer.tsx
+++ b/packages/client/src/components/UIResourceRenderer.tsx
@@ -29,7 +29,10 @@ function getContentType(resource: Partial<Resource>): ResourceContentType | unde
   }
 }
 
-export const UIResourceRenderer: React.FC<UIResourceRendererProps> = (props) => {
+export const UIResourceRenderer = React.forwardRef<
+  HTMLIFrameElement | null,
+  UIResourceRendererProps
+>((props, ref) => {
   const { resource, onUIAction, supportedContentTypes, htmlProps, remoteDomProps } = props;
   const contentType = getContentType(resource);
 
@@ -40,7 +43,14 @@ export const UIResourceRenderer: React.FC<UIResourceRendererProps> = (props) => 
   switch (contentType) {
     case 'rawHtml':
     case 'externalUrl':
-      return <HTMLResourceRenderer resource={resource} onUIAction={onUIAction} {...htmlProps} />;
+      return (
+        <HTMLResourceRenderer
+          resource={resource}
+          onUIAction={onUIAction}
+          {...htmlProps}
+          ref={ref}
+        />
+      );
     case 'remoteDom':
       return (
         <RemoteDOMResourceRenderer
@@ -53,4 +63,6 @@ export const UIResourceRenderer: React.FC<UIResourceRendererProps> = (props) => 
     default:
       return <p className="text-red-500">Unsupported resource type.</p>;
   }
-};
+});
+
+UIResourceRenderer.displayName = 'UIResourceRenderer';

--- a/packages/client/src/components/__tests__/HTMLResourceRenderer.test.tsx
+++ b/packages/client/src/components/__tests__/HTMLResourceRenderer.test.tsx
@@ -4,6 +4,7 @@ import { HTMLResourceRenderer, HTMLResourceRendererProps } from '../HTMLResource
 import { vi } from 'vitest';
 import type { Resource } from '@modelcontextprotocol/sdk/types.js';
 import { UIActionResult } from '../../types.js';
+import React from 'react';
 
 describe('HTMLResource component', () => {
   const mockOnUIAction = vi.fn();
@@ -286,6 +287,12 @@ describe('HTMLResource iframe communication', () => {
         expect.objectContaining({ message: errorMessage }),
       );
     });
+  });
+
+  it('should pass ref to iframe', () => {
+    const ref = React.createRef<HTMLIFrameElement>();
+    render(<HTMLResourceRenderer resource={mockResourceBaseForUIActionTests} ref={ref} />);
+    expect(ref.current).toBeInTheDocument();
   });
 
   it('should not attempt to call onUIAction if iframeRef.current is null (e.g. resource error)', async () => {

--- a/packages/client/src/components/__tests__/UIResourceRenderer.unmocked.test.tsx
+++ b/packages/client/src/components/__tests__/UIResourceRenderer.unmocked.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import { Resource } from '@modelcontextprotocol/sdk/types.js';
+import { UIResourceRenderer } from '../UIResourceRenderer';
+
+describe('UIResourceRenderer', () => {
+  const testResource: Partial<Resource> = {
+    mimeType: 'text/html',
+    text: '<html><body><h1>Test Content</h1><script>console.log("iframe script loaded for onUIAction tests")</script></body></html>',
+    uri: 'ui://test-resource',
+  };
+  it('should pass ref to HTMLResourceRenderer', () => {
+    const ref = React.createRef<HTMLIFrameElement>();
+    render(<UIResourceRenderer resource={testResource} ref={ref} />);
+    expect(ref.current).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This fixes external ref passing to UIResourceRenderer (currently it's not possible)