### PR TITLE
fix missing links in docs nav

### DIFF
--- a/docs/src/.vitepress/config.ts
+++ b/docs/src/.vitepress/config.ts
@@ -143,7 +143,15 @@ export default defineConfig({
                 {
                   text: 'Web Component Usage & Examples',
                   link: '/guide/client/wc-usage-examples',
-                }
+                },
+                {
+                  text: 'HTMLResourceRenderer',
+                  link: '/guide/client/html-resource',
+                },
+                {
+                  text: 'RemoteDOMResourceRenderer',
+                  link: '/guide/client/remote-dom-resource',
+                },
               ],
             },
             {


### PR DESCRIPTION
Love the doc site updates! 

I found that 2 pages were missing in the nav:

- https://mcpui.dev/guide/client/html-resource
- https://mcpui.dev/guide/client/remote-dom-resource

I'm unsure if these were omitted from the nav to avoid confusion or if they simply fell through the cracks. 

I tucked them both under `client SDK` > `UIResourceRenderer`

<img width="343" height="418" alt="image" src="https://github.com/user-attachments/assets/ede8ef1c-bdb5-4d2c-9df8-927b7c00f1fd" />

