### PR TITLE
bump semantic-release to 24 to avoid dep conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jsdom": "^23.0.1",
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "semantic-release": "^23.1.1",
+    "semantic-release": "^24",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3",


### PR DESCRIPTION
was unable to install to project until i implemented this fix due to:

```
> mcp-ui % npm install

npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: mcp-ui@5.2.0
npm error Found: semantic-release@23.1.1
npm error node_modules/semantic-release
npm error   dev semantic-release@"^23.1.1" from the root project
npm error
npm error Could not resolve dependency:
npm error peer semantic-release@">=24.1.0" from @semantic-release/github@11.0.3
npm error node_modules/@semantic-release/github
npm error   dev @semantic-release/github@"^11.0.3" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
```

