### PR TITLE
docs: fix undefined variable in code examples

### DIFF
--- a/docs/src/guide/client/resource-renderer.md
+++ b/docs/src/guide/client/resource-renderer.md
@@ -196,7 +196,7 @@ if (urlParams.get('waitForRenderData') === 'true') {
       } else {
         customRenderData = event.data.payload.renderData;
         // Now you can render the UI with the received data
-        renderUI(renderData);
+        renderUI(customRenderData);
       }
     }
   });

--- a/docs/src/guide/embeddable-ui.md
+++ b/docs/src/guide/embeddable-ui.md
@@ -290,7 +290,7 @@ if (urlParams.get("waitForRenderData") === "true") {
       } else {
         customRenderData = event.data.payload.renderData;
         // Now you can render the UI with the received data
-        renderUI(renderData);
+        renderUI(customRenderData);
       }
     }
   });


### PR DESCRIPTION
A minor code nit, this updates code samples for embeddable UI and resource rendering by using the correct variable name, `customRenderData`. Otherwise, technically the code as documented would result in a `ReferenceError` for the undefined `renderData` variable passed to the `renderUI()` call.
