### PR TITLE
refactor: update isUIResource to use EmbeddedResource type

### DIFF
--- a/sdks/typescript/client/src/utils/isUIResource.ts
+++ b/sdks/typescript/client/src/utils/isUIResource.ts
@@ -1,5 +1,9 @@
-import type { Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
 
-export function isUIResource<T extends { type: string; resource?: Partial<Resource> }>(content: T): content is T & { type: 'resource'; resource: Partial<Resource> } {
-    return (content.type === 'resource' && content.resource?.uri?.startsWith('ui://')) ?? false;
+export function isUIResource<
+  T extends { type: string; resource?: Partial<EmbeddedResource['resource']> },
+>(
+  content: T,
+): content is T & { type: 'resource'; resource: Partial<EmbeddedResource['resource']> } {
+  return (content.type === 'resource' && content.resource?.uri?.startsWith('ui://')) ?? false;
 }


### PR DESCRIPTION
## Summary
This PR updates the `isUIResource` function to use `EmbeddedResource['resource']` type instead of `Resource`, aligning with the changes made in PR #117.

## Changes
- Changed import from `Resource` to `EmbeddedResource`
- Updated the generic type constraint from `Partial<Resource>` to `Partial<EmbeddedResource['resource']>`
- Updated the return type accordingly

## Motivation
This change ensures type consistency across the codebase, following the same pattern established in #117 where `UIResourceRenderer` was updated to use `EmbeddedResource`.

## Testing
- ✅ Build passes
- ✅ Linting passes
- ✅ Type checking passes