### PR TITLE
docs: update ruby docs to fix broken markdown

### DIFF
--- a/docs/src/guide/server/ruby/usage-examples.md
+++ b/docs/src/guide/server/ruby/usage-examples.md
@@ -114,6 +114,7 @@ puts "Resource 5: #{JSON.pretty_generate(resource5)}"
 
 # These resource objects would then be included in the 'content' array
 # of a toolResult in an MCP interaction.
+```
 
 ## Error Handling
 


### PR DESCRIPTION
It appears that the intention of the docs was to have a separate section for error handling but got cut off between the comments and headers and code blocks.  

This PR attempts to fix the formatting and make it so that copying the code doesn't have errors in it.

before:
<img width="1114" height="457" alt="Screenshot 2025-10-16 at 10 06 41 AM" src="https://github.com/user-attachments/assets/eb7be628-df4f-46ae-8a0b-39992e985d09" />

after:
<img width="1227" height="452" alt="Screenshot 2025-10-16 at 10 07 03 AM" src="https://github.com/user-attachments/assets/e4cd9b48-1e64-4063-98bc-8eefe449e4bf" />

Thanks!