### PR TITLE
fix: enable bidirectional message relay in rawhtml proxy mode

### DIFF
--- a/sdks/typescript/client/scripts/proxy/index.html
+++ b/sdks/typescript/client/scripts/proxy/index.html
@@ -54,15 +54,21 @@
 
         // Wait for HTML content from parent
         window.addEventListener('message', (event) => {
-          if (event.source === window.parent && event.data && event.data.type === 'ui-html-content') {
-            const payload = event.data.payload || {};
-            const html = payload.html;
-            const sandbox = payload.sandbox;
-            if (typeof sandbox === 'string') {
-              inner.setAttribute('sandbox', sandbox);
-            }
-            if (typeof html === 'string') {
-              inner.srcdoc = html;
+          if (event.source === window.parent) {
+            if (event.data && event.data.type === 'ui-html-content') {
+              const payload = event.data.payload || {};
+              const html = payload.html;
+              const sandbox = payload.sandbox;
+              if (typeof sandbox === 'string') {
+                inner.setAttribute('sandbox', sandbox);
+              }
+              if (typeof html === 'string') {
+                inner.srcdoc = html;
+              }
+            } else {
+              if (inner && inner.contentWindow) {
+                inner.contentWindow.postMessage(event.data, '*');
+              }
             }
           } else if (event.source === inner.contentWindow) {
             // Relay messages from inner to parent


### PR DESCRIPTION
## Summary

This PR adds **true bidirectional message relay** to the rawhtml proxy mode, enabling full two-way communication between the parent window and the inner iframe.

## Problem

Currently, the proxy only relays messages in one direction:
- ✅ Inner iframe → Parent: Working
- ❌ Parent → Inner iframe: Only `ui-html-content` is handled

This limitation prevents parent windows from sending custom messages to the inner iframe, restricting interactive capabilities.

## Solution

Modified the message event listener in `index.html` to relay **all messages** from parent to inner iframe (not just `ui-html-content`):

```javascript
// Before: Only ui-html-content was handled
if (event.source === window.parent && event.data && event.data.type === 'ui-html-content') {
  // handle HTML content
}

// After: All parent messages are relayed
if (event.source === window.parent) {
  if (event.data && event.data.type === 'ui-html-content') {
    // handle HTML content
  } else {
    // relay other messages to inner iframe
    inner.contentWindow.postMessage(event.data, '*');
  }
}
```

## Benefits

This enables MCP-UI applications to implement:
- ✨ Parent-initiated UI updates
- ✨ Action acknowledgments
- ✨ State synchronization
- ✨ Custom event handling
- ✨ Bidirectional protocols

## Backward Compatibility

✅ Fully backward compatible - existing `ui-html-content` flow is unchanged

## Testing

Tested with:
- Serving the proxy via Python HTTP server
- Custom messages from parent to inner iframe
- Verified message relay in both directions using console logging

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)