### PR TITLE
fix(client): use type-only imports for @modelcontextprotocol/sdk types

### DIFF
--- a/sdks/typescript/client/src/components/UIResourceRendererWC.tsx
+++ b/sdks/typescript/client/src/components/UIResourceRendererWC.tsx
@@ -2,7 +2,7 @@ import r2wc from '@r2wc/react-to-web-component';
 import { UIResourceRenderer, type UIResourceRendererProps } from './UIResourceRenderer';
 import { FC, useCallback, useRef } from 'react';
 import { UIActionResult } from '../types';
-import { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
 
 
 type UIResourceRendererWCProps = Omit<UIResourceRendererProps, 'resource' | 'onUIAction'> & {

--- a/sdks/typescript/client/src/components/__tests__/UIResourceRenderer.unmocked.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/UIResourceRenderer.unmocked.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddedResource } from '@modelcontextprotocol/sdk/types.js';
 import { UIResourceRenderer } from '../UIResourceRenderer';
 import { UI_METADATA_PREFIX } from '../../types';
 

--- a/sdks/typescript/client/src/utils/metadataUtils.ts
+++ b/sdks/typescript/client/src/utils/metadataUtils.ts
@@ -1,4 +1,4 @@
-import { Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { Resource } from '@modelcontextprotocol/sdk/types.js';
 import { UI_METADATA_PREFIX, UIResourceMetadata } from '../types';
 
 export function getResourceMetadata(resource: Partial<Resource>): Record<string, unknown> {

--- a/sdks/typescript/client/src/utils/processResource.ts
+++ b/sdks/typescript/client/src/utils/processResource.ts
@@ -1,4 +1,4 @@
-import { EmbeddedResource, Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { EmbeddedResource, Resource } from '@modelcontextprotocol/sdk/types.js';
 
 type ProcessResourceResult = {
   error?: string;


### PR DESCRIPTION
Change value imports to `import type` syntax for SDK types to prevent bundlers from including Node.js server code in browser builds.

When bundling @mcp-ui/client for pure browser environments, the @modelcontextprotocol/sdk's server-side code (which imports Express) was being included due to the import chain, causing "require is not defined" errors at runtime.

Since the SDK is only used for TypeScript types (not runtime values), using `import type` ensures these imports are stripped at compile time and don't trigger bundling of the SDK's server-side modules.

Files changed:
- UIResourceRendererWC.tsx: EmbeddedResource type
- metadataUtils.ts: Resource type
- processResource.ts: EmbeddedResource, Resource types
- UIResourceRenderer.unmocked.test.tsx: EmbeddedResource type

🤖 Generated with [Claude Code](https://claude.com/claude-code)