### PR TITLE
fix: update MCP Apps adapter mimetype

### DIFF
--- a/docs/src/guide/mcp-apps.md
+++ b/docs/src/guide/mcp-apps.md
@@ -210,7 +210,7 @@ createUIResource({
 
 ## MIME Type
 
-When the MCP Apps adapter is enabled, the resource MIME type is automatically set to `text/html+mcp`. This is the expected MIME type for MCP Apps-compliant hosts.
+When the MCP Apps adapter is enabled, the resource MIME type is automatically set to `text/html;profile=mcp`. This is the expected MIME type for MCP Apps-compliant hosts.
 
 ## Receiving Data in Your Widget
 

--- a/docs/src/guide/supported-hosts.md
+++ b/docs/src/guide/supported-hosts.md
@@ -31,7 +31,7 @@ These hosts use different protocols but can render MCP-UI widgets via adapters:
 MCP-UI provides two adapters to bridge protocol differences:
 
 - **Apps SDK Adapter**: For ChatGPT and other Apps SDK hosts. Uses `text/html+skybridge` MIME type.
-- **MCP Apps Adapter**: For hosts implementing the [MCP Apps SEP protocol](https://github.com/modelcontextprotocol/ext-apps). Uses `text/html+mcp` MIME type.
+- **MCP Apps Adapter**: For hosts implementing the [MCP Apps SEP protocol](https://github.com/modelcontextprotocol/ext-apps). Uses `text/html;profile=mcp` MIME type.
 
 Both adapters are automatically injected into your HTML when enabled, translating MCP-UI messages to the host's native protocol.
 

--- a/sdks/typescript/server/src/__tests__/adapters/adapter-integration.test.ts
+++ b/sdks/typescript/server/src/__tests__/adapters/adapter-integration.test.ts
@@ -482,14 +482,14 @@ describe('Adapter Integration', () => {
     });
 
     describe('getAdapterMimeType with MCP Apps', () => {
-      it('should return text/html+mcp for MCP Apps adapter', () => {
+      it('should return text/html;profile=mcp for MCP Apps adapter', () => {
         const result = getAdapterMimeType({
           mcpApps: {
             enabled: true,
           },
         });
 
-        expect(result).toBe('text/html+mcp');
+        expect(result).toBe('text/html;profile=mcp');
       });
     });
 
@@ -555,7 +555,7 @@ describe('Adapter Integration', () => {
       expect(getAdapterMimeType({ appsSdk: { enabled: true } })).toBe('text/html+skybridge');
 
       // MCP Apps adapter
-      expect(getAdapterMimeType({ mcpApps: { enabled: true } })).toBe('text/html+mcp');
+      expect(getAdapterMimeType({ mcpApps: { enabled: true } })).toBe('text/html;profile=mcp');
 
       // No adapter
       expect(getAdapterMimeType({})).toBeUndefined();

--- a/sdks/typescript/server/src/adapters/mcp-apps/README.md
+++ b/sdks/typescript/server/src/adapters/mcp-apps/README.md
@@ -219,7 +219,7 @@ server.registerTool(
 
 ## MIME Type
 
-When the MCP Apps adapter is enabled, the resource MIME type is automatically set to `text/html+mcp`, which is the expected type for MCP Apps hosts.
+When the MCP Apps adapter is enabled, the resource MIME type is automatically set to `text/html;profile=mcp`, which is the expected type for MCP Apps hosts.
 
 ## Mutual Exclusivity with Apps SDK Adapter
 

--- a/sdks/typescript/server/src/types.ts
+++ b/sdks/typescript/server/src/types.ts
@@ -18,7 +18,7 @@ export const RESOURCE_URI_META_KEY = 'ui/resourceUri' as const;
 // text/html for rawHtml content, text/uri-list for externalUrl content
 export type MimeType =
   | 'text/html'
-  | 'text/html+mcp'
+  | 'text/html;profile=mcp'
   | 'text/html+skybridge'
   | 'text/uri-list'
   | 'application/vnd.mcp-ui.remote-dom+javascript; framework=react'

--- a/sdks/typescript/server/src/utils.ts
+++ b/sdks/typescript/server/src/utils.ts
@@ -79,9 +79,9 @@ export function getAdapterMimeType(adaptersConfig?: AdaptersConfig): string | un
     return adaptersConfig.appsSdk.mimeType ?? 'text/html+skybridge';
   }
 
-  // MCP Apps adapter uses text/html+mcp as per the ext-apps specification
+  // MCP Apps adapter uses text/html;profile=mcp as per the ext-apps specification
   if (adaptersConfig.mcpApps?.enabled) {
-    return 'text/html+mcp';
+    return 'text/html;profile=mcp';
   }
 
   // Future adapters can be added here by checking for their config and returning their mime type.


### PR DESCRIPTION
The mimetype has changed from `text/html+mcp` to `text/html;profile=mcp`.

See https://github.com/modelcontextprotocol/ext-apps/issues/59