### PR TITLE
feat(client): add hostCapabilities prop to AppRenderer

### DIFF
--- a/sdks/typescript/client/src/components/AppRenderer.tsx
+++ b/sdks/typescript/client/src/components/AppRenderer.tsx
@@ -21,6 +21,7 @@ import {
 import {
   AppBridge,
   RESOURCE_MIME_TYPE,
+  type McpUiHostCapabilities,
   type McpUiMessageRequest,
   type McpUiMessageResult,
   type McpUiOpenLinkRequest,
@@ -59,6 +60,36 @@ export interface AppRendererHandle {
 export interface AppRendererProps {
   /** MCP client connected to the server providing the tool. Omit to disable automatic MCP forwarding and use custom handlers instead. */
   client?: Client;
+
+  /**
+   * Host capabilities to advertise to the guest app during initialization.
+   *
+   * When provided, these capabilities are passed directly to the AppBridge
+   * and sent to the guest app in the `ui/initialize` response. This is the
+   * recommended way to declare host capabilities when using callback-based
+   * handlers (onCallTool, onReadResource, etc.) without an MCP client.
+   *
+   * When omitted, capabilities are derived from the `client` prop:
+   * - `openLinks` is always advertised
+   * - `serverTools` is advertised if `client.getServerCapabilities().tools` exists
+   * - `serverResources` is advertised if `client.getServerCapabilities().resources` exists
+   *
+   * @example Declare capabilities for a callback-based host
+   * ```tsx
+   * <AppRenderer
+   *   hostCapabilities={{
+   *     openLinks: {},
+   *     serverTools: {},
+   *     serverResources: {},
+   *     logging: {},
+   *   }}
+   *   onCallTool={handleCallTool}
+   *   onReadResource={handleReadResource}
+   *   // ...
+   * />
+   * ```
+   */
+  hostCapabilities?: McpUiHostCapabilities;
 
   /** Name of the MCP tool to render UI for */
   toolName: string;
@@ -261,6 +292,7 @@ export interface AppRendererProps {
 export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((props, ref) => {
   const {
     client,
+    hostCapabilities,
     toolName,
     sandbox,
     toolResourceUri,
@@ -333,18 +365,19 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
 
     const createBridge = () => {
       try {
-        const serverCapabilities = client?.getServerCapabilities();
+        // Use explicit hostCapabilities if provided, otherwise derive from client
+        const capabilities: McpUiHostCapabilities = hostCapabilities ?? {
+          openLinks: {},
+          serverTools: client?.getServerCapabilities()?.tools,
+          serverResources: client?.getServerCapabilities()?.resources,
+        };
         const bridge = new AppBridge(
           client ?? null,
           {
             name: 'MCP-UI Host',
             version: '1.0.0',
           },
-          {
-            openLinks: {},
-            serverTools: serverCapabilities?.tools,
-            serverResources: serverCapabilities?.resources,
-          },
+          capabilities,
         );
 
         // Register message handler
@@ -419,7 +452,7 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
     return () => {
       mounted = false;
     };
-  }, [client]);
+  }, [client, hostCapabilities]);
 
   // Effect 2: Fetch HTML if not provided
   useEffect(() => {

--- a/sdks/typescript/client/src/components/__tests__/AppRenderer.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/AppRenderer.test.tsx
@@ -602,6 +602,87 @@ describe('<AppRenderer />', () => {
     });
   });
 
+  describe('hostCapabilities prop', () => {
+    it('should pass explicit hostCapabilities to AppBridge', async () => {
+      const { AppBridge } = await import('@modelcontextprotocol/ext-apps/app-bridge');
+
+      const customCapabilities = {
+        openLinks: {},
+        serverTools: {},
+        serverResources: {},
+        logging: {},
+      };
+
+      render(
+        <AppRenderer
+          {...defaultProps}
+          html="<html></html>"
+          hostCapabilities={customCapabilities}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-frame')).toBeInTheDocument();
+      });
+
+      expect(AppBridge).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        customCapabilities,
+      );
+    });
+
+    it('should derive capabilities from client when hostCapabilities is not provided', async () => {
+      const { AppBridge } = await import('@modelcontextprotocol/ext-apps/app-bridge');
+
+      render(<AppRenderer {...defaultProps} html="<html></html>" />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-frame')).toBeInTheDocument();
+      });
+
+      expect(AppBridge).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        {
+          openLinks: {},
+          serverTools: {},
+          serverResources: {},
+        },
+      );
+    });
+
+    it('should work with hostCapabilities and no client', async () => {
+      const { AppBridge } = await import('@modelcontextprotocol/ext-apps/app-bridge');
+
+      const customCapabilities = {
+        openLinks: {},
+        serverTools: {},
+        serverResources: {},
+        logging: {},
+      };
+
+      render(
+        <AppRenderer
+          toolName="test-tool"
+          sandbox={{ url: new URL('http://localhost:8081/sandbox.html') }}
+          html="<html></html>"
+          hostCapabilities={customCapabilities}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-frame')).toBeInTheDocument();
+      });
+
+      // Should pass null client but explicit capabilities
+      expect(AppBridge).toHaveBeenCalledWith(
+        null,
+        expect.anything(),
+        customCapabilities,
+      );
+    });
+  });
   describe('no client', () => {
     it('should work without client when html is provided', async () => {
       const props: AppRendererProps = {

--- a/sdks/typescript/client/src/index.ts
+++ b/sdks/typescript/client/src/index.ts
@@ -28,6 +28,7 @@ export {
 export {
   AppBridge,
   PostMessageTransport,
+  type McpUiHostCapabilities,
   type McpUiHostContext,
 } from '@modelcontextprotocol/ext-apps/app-bridge';
 


### PR DESCRIPTION
## Problem

The `AppRenderer` component derives `hostCapabilities` solely from `client.getServerCapabilities()`, mapping only `tools → serverTools` and `resources → serverResources` (plus hardcoding `openLinks: {}`). Hosts using callback-based handlers (`onCallTool`, `onReadResource`, etc.) without an MCP `Client` have no way to advertise their capabilities to guest apps during the `ui/initialize` handshake.

This means guest apps see `{ openLinks: {} }` and don't know the host supports tool proxying, resource reads, logging, etc. — even though the host provides handlers for all of them.

## Solution

Add an optional `hostCapabilities` prop to `AppRendererProps`:

```tsx
<AppRenderer
  hostCapabilities={{
    openLinks: {},
    serverTools: {},
    serverResources: {},
    logging: {},
  }}
  onCallTool={handleCallTool}
  onReadResource={handleReadResource}
  onLoggingMessage={handleLoggingMessage}
  // ...
/>
```

When provided, the capabilities object is passed directly to the `AppBridge` constructor. When omitted, the existing client-derived logic is used unchanged. Fully backwards-compatible.

## Changes

- **`AppRenderer.tsx`** — Import `McpUiHostCapabilities`, add prop with JSDoc, wire into bridge creation, add to `useEffect` deps
- **`AppRenderer.test.tsx`** — 3 new tests: explicit caps passed through, client-derived fallback works, no-client + explicit caps works
- **`index.ts`** — Re-export `McpUiHostCapabilities` type for consumer convenience

## Context

We're implementing this in [goose](https://github.com/block/goose) where we render MCP Apps in an Electron desktop app. We use callback-based handlers to proxy tool calls and resource reads through our server, so we don't have an MCP `Client` instance to pass. Without this prop, guest apps can't feature-detect our host capabilities.