### PR TITLE
fix(client): prevent AppFrame setup from stalling on mid-flight re-render

### DIFF
--- a/sdks/typescript/client/src/components/AppFrame.tsx
+++ b/sdks/typescript/client/src/components/AppFrame.tsx
@@ -19,10 +19,13 @@ import { setupSandboxProxyIframe } from '../utils/app-host-utils';
  * to set CSP via HTTP headers (tamper-proof) rather than relying on meta tags or
  * postMessage-based CSP injection (which can be bypassed by malicious content).
  *
+ * Accepts the base href as a string (not a URL instance) so callers can key React
+ * effects on the href value rather than the URL object reference.
+ *
  * @see https://github.com/modelcontextprotocol/ext-apps/pull/234
  */
-function buildSandboxUrl(baseUrl: URL, csp?: McpUiResourceCsp): URL {
-  const url = new URL(baseUrl.href);
+function buildSandboxUrl(baseUrlHref: string, csp?: McpUiResourceCsp): URL {
+  const url = new URL(baseUrlHref);
   if (csp && Object.keys(csp).length > 0) {
     url.searchParams.set('csp', JSON.stringify(csp));
   }
@@ -139,17 +142,24 @@ export const AppFrame = (props: AppFrameProps) => {
     onErrorRef.current = onError;
   });
 
+  // Key the effect on the href string rather than the URL object so that callers
+  // passing `new URL(...)` inline (creating a fresh reference every render) do not
+  // tear down and rebuild the sandbox on each parent re-render. See issue #193.
+  const sandboxUrlHref = sandbox.url.href;
+
   // Effect 1: Set up sandbox iframe and connect AppBridge
   useEffect(() => {
     // Build sandbox URL with CSP query parameter for HTTP header-based CSP enforcement.
     // Servers that support this will parse the CSP from the query param and set it via
     // HTTP headers (tamper-proof). The CSP is also sent via postMessage as fallback.
-    const sandboxUrl = buildSandboxUrl(sandbox.url, sandbox.csp);
+    const sandboxUrl = buildSandboxUrl(sandboxUrlHref, sandbox.csp);
     const sandboxUrlString = sandboxUrl.href;
 
-    // If we already have an iframe set up for this sandbox URL AND the same appBridge, skip setup
-    // This preserves the iframe state across React re-renders (including StrictMode)
-    // but ensures isolation when switching to a different app/resource (different appBridge)
+    // If we already have an iframe set up for this sandbox URL AND the same appBridge, skip setup.
+    // This preserves the iframe state across React re-renders (including StrictMode) but ensures
+    // isolation when switching to a different app/resource (different appBridge). The dedupe refs
+    // are only set once setup reaches `setBridgeConnected(true)` below, so an aborted in-flight
+    // setup can never poison this guard (see issue #193).
     if (
       currentSandboxUrlRef.current === sandboxUrlString &&
       currentAppBridgeRef.current === appBridge &&
@@ -181,8 +191,6 @@ export const AppFrame = (props: AppFrameProps) => {
         if (!mounted) return;
 
         iframeRef.current = iframe;
-        currentSandboxUrlRef.current = sandboxUrlString;
-        currentAppBridgeRef.current = appBridge;
         if (containerRef.current) {
           containerRef.current.appendChild(iframe);
         }
@@ -223,6 +231,13 @@ export const AppFrame = (props: AppFrameProps) => {
 
         if (!mounted) return;
 
+        // Only mark the URL + bridge as the "current" setup once connect succeeds.
+        // If we wrote these earlier and the setup aborted (e.g. parent re-rendered
+        // before `connect` resolved), a subsequent effect run would match the guard
+        // above and short-circuit, leaving the bridge permanently disconnected.
+        currentSandboxUrlRef.current = sandboxUrlString;
+        currentAppBridgeRef.current = appBridge;
+
         setBridgeConnected(true);
       } catch (err) {
         console.error('[AppFrame] Error:', err);
@@ -238,7 +253,7 @@ export const AppFrame = (props: AppFrameProps) => {
     return () => {
       mounted = false;
     };
-  }, [sandbox.url, sandbox.csp, appBridge]);
+  }, [sandboxUrlHref, sandbox.csp, appBridge]);
 
   // Effect 2: Send HTML to sandbox when bridge is connected
   useEffect(() => {

--- a/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
@@ -333,6 +333,76 @@ describe('<AppFrame />', () => {
       });
     });
 
+    it('should not tear down iframe when parent passes a new URL instance with the same href', async () => {
+      // Regression test for https://github.com/MCP-UI-Org/mcp-ui/issues/193
+      // When a parent component renders with `sandbox={{ url: new URL(...) }}` inline
+      // (the pattern documented in AppRenderer's JSDoc example), a new URL reference is
+      // produced on every render. The effect must key on the href string, not the URL
+      // object identity, otherwise identical-content re-renders rebuild the sandbox.
+      const { rerender } = render(<AppFrame {...getPropsWithBridge()} />);
+
+      await act(() => {
+        onReadyResolve();
+      });
+
+      await act(() => {
+        registeredOninitialized?.();
+      });
+
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(1);
+
+      // Same href, fresh URL instance
+      const sameHrefNewRef = new URL(defaultProps.sandbox.url.href);
+      expect(sameHrefNewRef).not.toBe(defaultProps.sandbox.url);
+      expect(sameHrefNewRef.href).toBe(defaultProps.sandbox.url.href);
+      rerender(<AppFrame {...getPropsWithBridge({ sandbox: { url: sameHrefNewRef } })} />);
+
+      // Iframe must be preserved — the effect should dedupe on href, not reference
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still connect bridge if parent re-renders with new URL reference mid-setup', async () => {
+      // Regression test for https://github.com/MCP-UI-Org/mcp-ui/issues/193
+      // With the bug present, a parent re-render while `await onReady` was pending would
+      // (a) fire the cleanup, setting `mounted = false`, and (b) short-circuit the re-run
+      // against stale dedupe refs written too early — leaving the bridge permanently
+      // disconnected and the app blank.
+      const { rerender } = render(<AppFrame {...getPropsWithBridge()} />);
+
+      // Wait for the initial effect to reach `await onReady` (setup is parked)
+      await waitFor(() => {
+        expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(1);
+      });
+
+      // Parent re-renders with a new URL instance (same href) before onReady resolves
+      const sameHrefNewRef = new URL(defaultProps.sandbox.url.href);
+      rerender(<AppFrame {...getPropsWithBridge({ sandbox: { url: sameHrefNewRef } })} />);
+
+      // Now resolve the original iframe's onReady and finish initialization
+      await act(() => {
+        onReadyResolve();
+      });
+
+      await waitFor(() => {
+        expect(mockAppBridge.connect).toHaveBeenCalledTimes(1);
+      });
+
+      await act(() => {
+        registeredOninitialized?.();
+      });
+
+      // HTML must reach the sandbox — without the fix, this call never happens.
+      await waitFor(() => {
+        expect(mockAppBridge.sendSandboxResourceReady).toHaveBeenCalledWith({
+          html: defaultProps.html,
+          csp: undefined,
+        });
+      });
+
+      // No redundant iframe creation
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(1);
+    });
+
     it('should update HTML content without recreating iframe', async () => {
       const { rerender } = render(<AppFrame {...getPropsWithBridge()} />);
 


### PR DESCRIPTION
## Summary

Fixes #193 — `AppRenderer` sometimes renders nothing (blank, no error) when the parent passes `sandbox={{ url: new URL(...) }}` inline and happens to re-render while the sandbox iframe is still loading. The bridge ends up permanently disconnected and the HTML is never sent to the sandbox.

### Root cause

In `AppFrame.tsx` Effect 1:

- The effect depends on the **URL object** (`sandbox.url`), which a new `new URL(...)` expression creates fresh on every parent render.
- The dedupe guard compares the **href string** (`currentSandboxUrlRef.current === sandboxUrlString`), not the URL reference.
- The setup writes `currentSandboxUrlRef.current` synchronously at line 184 — *before* awaiting `onReady` and `appBridge.connect()`.

Race timeline when a parent re-render lands during `await onReady`:
1. React runs cleanup first → `mounted = false` for the in-flight run.
2. The re-run's guard matches on the href string and short-circuits. No new `mounted = true` closure is created.
3. The original setup resumes, hits `if (!mounted) return;`, and bails out before `appBridge.connect()` / `setBridgeConnected(true)`.
4. Effect 2 (gated on `bridgeConnected`) never sends the HTML. The sandbox iframe loads but the app stays blank forever.

See the linked issue for a full trace with line numbers.

### Fix

Two complementary changes in [`sdks/typescript/client/src/components/AppFrame.tsx`](https://github.com/MCP-UI-Org/mcp-ui/blob/main/sdks/typescript/client/src/components/AppFrame.tsx):

1. **Key the effect on the href string.** `buildSandboxUrl` now takes `baseUrlHref: string`, and the effect depends on `sandbox.url.href`. Same-href re-renders no longer trigger Effect 1, eliminating the race window for the documented inline-`new URL(...)` pattern.
2. **Defer the dedupe-ref writes.** `currentSandboxUrlRef` / `currentAppBridgeRef` are now written *after* `appBridge.connect()` resolves, not before `await onReady`. An aborted in-flight setup cannot poison the dedupe guard, so legitimate mid-setup URL or bridge changes are handled correctly too.

## Test plan

- [x] `pnpm --filter @mcp-ui/client test` — 68 passing (all previous 66 plus two new regression tests).
- [x] Verified the new test `should still connect bridge if parent re-renders with new URL reference mid-setup` **fails on the pre-fix code** (`mockAppBridge.connect` called 0 times) and passes with the fix applied.
- [x] Prettier + ESLint clean.
- [x] `pnpm --filter @mcp-ui/client build` passes (tsc + vite build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
