### PR TITLE
fix(client): seed AppBridge host context before connect

### DIFF
--- a/sdks/typescript/client/src/components/AppRenderer.tsx
+++ b/sdks/typescript/client/src/components/AppRenderer.tsx
@@ -308,6 +308,7 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
   const onReadResourceRef = useRef(onReadResource);
   const onListPromptsRef = useRef(onListPrompts);
   const onFallbackRequestRef = useRef(onFallbackRequest);
+  const hostContextRef = useRef(hostContext);
 
   useEffect(() => {
     onMessageRef.current = onMessage;
@@ -321,6 +322,7 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
     onReadResourceRef.current = onReadResource;
     onListPromptsRef.current = onListPrompts;
     onFallbackRequestRef.current = onFallbackRequest;
+    hostContextRef.current = hostContext;
   });
 
   // Expose send methods via ref for Host → Guest notifications
@@ -357,11 +359,12 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
           serverResources: serverCapabilities?.resources,
         };
 
-        const bridge = new AppBridge(
-          client ?? null,
-          finalHostInfo,
-          finalHostCapabilities,
-        );
+        const initialHostContext = hostContextRef.current;
+        const bridge = initialHostContext
+          ? new AppBridge(client ?? null, finalHostInfo, finalHostCapabilities, {
+              hostContext: initialHostContext,
+            })
+          : new AppBridge(client ?? null, finalHostInfo, finalHostCapabilities);
 
         currentBridge = bridge;
 
@@ -541,7 +544,14 @@ export const AppRenderer = forwardRef<AppRendererHandle, AppRendererProps>((prop
   // Effect 3: Sync host context when it changes
   useEffect(() => {
     if (appBridge && hostContext) {
-      appBridge.setHostContext(hostContext);
+      try {
+        appBridge.setHostContext(hostContext);
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (error.message.includes('Not connected')) return;
+        setError(error);
+        onErrorRef.current?.(error);
+      }
     }
   }, [appBridge, hostContext]);
 

--- a/sdks/typescript/client/src/components/__tests__/AppRenderer.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/AppRenderer.test.tsx
@@ -37,6 +37,7 @@ vi.mock('../../utils/app-host-utils', () => ({
 
 // Store mock bridge instance for test access
 let mockBridgeInstance: Partial<AppBridge> | null = null;
+let mockSetHostContextImpl: (() => void) | undefined;
 
 // Mock AppBridge constructor
 vi.mock('@modelcontextprotocol/ext-apps/app-bridge', () => {
@@ -52,7 +53,7 @@ vi.mock('@modelcontextprotocol/ext-apps/app-bridge', () => {
         onreadresource: undefined,
         onlistprompts: undefined,
         fallbackRequestHandler: undefined,
-        setHostContext: vi.fn(),
+        setHostContext: vi.fn(() => mockSetHostContextImpl?.()),
         sendToolInputPartial: vi.fn(),
         sendToolCancelled: vi.fn(),
         sendToolListChanged: vi.fn(),
@@ -94,6 +95,7 @@ describe('<AppRenderer />', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockBridgeInstance = null;
+    mockSetHostContextImpl = undefined;
     mockAppFrame.mockClear();
 
     // Default mock implementations
@@ -253,6 +255,26 @@ describe('<AppRenderer />', () => {
   });
 
   describe('hostContext prop', () => {
+    it('should seed AppBridge with hostContext when provided', async () => {
+      const AppBridgeMock = vi.mocked(
+        (await import('@modelcontextprotocol/ext-apps/app-bridge')).AppBridge,
+      );
+      const hostContext = { theme: 'dark' as const };
+
+      render(<AppRenderer {...defaultProps} hostContext={hostContext} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('app-frame')).toBeInTheDocument();
+      });
+
+      expect(AppBridgeMock).toHaveBeenCalledWith(
+        mockClient,
+        expect.any(Object),
+        expect.any(Object),
+        { hostContext },
+      );
+    });
+
     it('should call setHostContext when hostContext is provided', async () => {
       const hostContext = { theme: 'dark' as const };
 
@@ -277,6 +299,28 @@ describe('<AppRenderer />', () => {
       await waitFor(() => {
         expect(mockBridgeInstance?.setHostContext).toHaveBeenCalledWith({ theme: 'dark' });
       });
+    });
+
+    it('should ignore not-connected errors while syncing hostContext', async () => {
+      const onError = vi.fn();
+      mockSetHostContextImpl = () => {
+        throw new Error('Not connected');
+      };
+
+      render(
+        <AppRenderer
+          {...defaultProps}
+          hostContext={{ theme: 'dark' as const }}
+          onError={onError}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockBridgeInstance?.setHostContext).toHaveBeenCalledWith({ theme: 'dark' });
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(screen.queryByText(/Error:/)).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
﻿## Summary
- seed `AppBridge` with the initial `hostContext` so `ui/initialize` has the value before the iframe transport connects
- keep later `hostContext` updates flowing through `setHostContext`, while ignoring the pre-connect `Not connected` notification race
- add AppRenderer coverage for constructor seeding and the not-connected sync path

Fixes #195

## To verify
- `pnpm --filter @mcp-ui/client test -- AppRenderer`
- `pnpm --filter @mcp-ui/client build`
- `pnpm --filter @mcp-ui/client lint`
- `git diff --check`
