### PR TITLE
chore: add `repository` field in package.json

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -2,6 +2,11 @@
   "name": "@mcp-ui/client",
   "version": "7.1.1",
   "description": "mcp-ui Client SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/client"
+  },
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/sdks/typescript/server/package.json
+++ b/sdks/typescript/server/package.json
@@ -3,6 +3,11 @@
   "version": "6.1.0",
   "private": false,
   "description": "mcp-ui Server SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/server"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/sdks/typescript/shared/package.json
+++ b/sdks/typescript/shared/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@mcp-ui/shared",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/shared"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
# Purpose

This PR add `repository` field to improve npm registry documentation/discoverability.

## Current behavior

<img width="1205" height="624" alt="Screenshot 2026-05-28 at 13 35 47" src="https://github.com/user-attachments/assets/450b7a04-c9b9-47f0-93e9-844eebbef971" />

## Changes

This pull request adds repository metadata to the `package.json` files for the TypeScript client, server, and shared SDKs. This helps with package discoverability and makes it easier for users and tools to trace the source code for these packages.

Repository metadata additions:

* Added a `repository` field to `sdks/typescript/client/package.json` to specify the GitHub repository and directory for the client SDK.
* Added a `repository` field to `sdks/typescript/server/package.json` to specify the GitHub repository and directory for the server SDK.
* Added a `repository` field to `sdks/typescript/shared/package.json` to specify the GitHub repository and directory for the shared SDK.