### PR TITLE
chore: add npm package source metadata

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -2,6 +2,15 @@
   "name": "@mcp-ui/client",
   "version": "7.1.1",
   "description": "mcp-ui Client SDK",
+  "homepage": "https://github.com/MCP-UI-Org/mcp-ui/tree/main/sdks/typescript/client#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/client"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/sdks/typescript/server/package.json
+++ b/sdks/typescript/server/package.json
@@ -3,6 +3,15 @@
   "version": "6.1.0",
   "private": false,
   "description": "mcp-ui Server SDK",
+  "homepage": "https://github.com/MCP-UI-Org/mcp-ui/tree/main/sdks/typescript/server#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/server"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

Adds npm metadata to the published TypeScript SDK packages so npm and tooling can link users to the source directories and issue tracker:

- `@mcp-ui/client`
- `@mcp-ui/server`

Both package READMEs already point users at this GitHub repository, but the published npm metadata currently omits `homepage`, `repository`, and `bugs`.

## Validation

Current published package metadata:

```sh
npm view @mcp-ui/client@7.1.1 name version homepage repository bugs --json
npm view @mcp-ui/server@6.1.0 name version homepage repository bugs --json
```

Both currently return only `name` and `version` for those fields.

Local checks:

```sh
node - <<'NODE'
const fs = require('fs');
const expected = [
  ['sdks/typescript/client/package.json', '@mcp-ui/client', 'sdks/typescript/client'],
  ['sdks/typescript/server/package.json', '@mcp-ui/server', 'sdks/typescript/server'],
];
for (const [file, name, directory] of expected) {
  const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
  if (pkg.name !== name) throw new Error(`${file}: wrong package name`);
  if (!pkg.homepage?.includes('github.com/MCP-UI-Org/mcp-ui')) throw new Error(`${name}: missing homepage`);
  if (pkg.repository?.type !== 'git') throw new Error(`${name}: bad repository type`);
  if (pkg.repository?.url !== 'git+https://github.com/MCP-UI-Org/mcp-ui.git') throw new Error(`${name}: bad repository url`);
  if (pkg.repository?.directory !== directory) throw new Error(`${name}: bad directory`);
  if (pkg.bugs?.url !== 'https://github.com/MCP-UI-Org/mcp-ui/issues') throw new Error(`${name}: bad bugs url`);
  console.log(`${name} metadata ok`);
}
NODE
npm pack --dry-run --ignore-scripts ./sdks/typescript/client
npm pack --dry-run --ignore-scripts ./sdks/typescript/server
git diff --check
```
