### PR TITLE
feat: Allow hosts to customize app iframe sandbox permissions

### DIFF
--- a/docs/src/guide/client/app-renderer.md
+++ b/docs/src/guide/client/app-renderer.md
@@ -43,7 +43,7 @@ function ToolUI({ client, toolName, toolInput, toolResult }) {
 |------|------|-------------|
 | `client` | `Client` | Optional MCP client for automatic resource fetching and MCP request forwarding. Omit to use custom handlers instead. |
 | `toolName` | `string` | Name of the MCP tool to render UI for. |
-| `sandbox` | `SandboxConfig` | Sandbox configuration with the proxy URL and optional CSP. |
+| `sandbox` | `SandboxConfig` | Sandbox configuration with the proxy URL, optional iframe permissions, and optional CSP. |
 | `html` | `string` | Optional pre-fetched HTML. If provided, skips all resource fetching. |
 | `toolResourceUri` | `string` | Optional pre-fetched resource URI. If not provided, fetched via the client. |
 | `toolInput` | `Record<string, unknown>` | Tool arguments to pass to the guest UI once it initializes. |
@@ -74,6 +74,29 @@ These override the automatic forwarding to the MCP client when provided:
 | `onListResourceTemplates` | `(params, extra) => Promise<ListResourceTemplatesResult>` | Handler for `resources/templates/list` requests. |
 | `onReadResource` | `(params, extra) => Promise<ReadResourceResult>` | Handler for `resources/read` requests. |
 | `onListPrompts` | `(params, extra) => Promise<ListPromptsResult>` | Handler for `prompts/list` requests. |
+
+### Sandbox Configuration
+
+`sandbox.url` points to the sandbox proxy HTML page that receives MCP app HTML and renders it in an iframe. By default, the iframe sandbox attribute is:
+
+```html
+sandbox="allow-scripts allow-same-origin allow-forms"
+```
+
+Use `sandbox.permissions` to override that attribute when your host needs stricter isolation:
+
+```tsx
+<AppRenderer
+  client={client}
+  toolName="my-tool"
+  sandbox={{
+    url: sandboxUrl,
+    permissions: 'allow-scripts allow-forms',
+  }}
+/>
+```
+
+Changing `sandbox.permissions` recreates the iframe so the new browser sandbox policy is applied. If your sandbox proxy is served from the same origin as your host app, avoid combining `allow-scripts` with `allow-same-origin` for untrusted MCP app HTML; `postMessage` does not require same-origin access. A dedicated, cookieless sandbox origin is recommended for production hosts.
 
 ### Ref Methods
 

--- a/docs/src/guide/client/walkthrough.md
+++ b/docs/src/guide/client/walkthrough.md
@@ -75,7 +75,7 @@ MCP Apps renders tool UIs in sandboxed iframes for security. You need a sandbox 
 ```
 
 ::: tip Production Setup
-For production, consider implementing Content Security Policy (CSP) headers and additional security measures. See [@modelcontextprotocol/ext-apps](https://github.com/modelcontextprotocol/ext-apps) for more details on secure sandbox proxy implementation.
+For production, consider implementing Content Security Policy (CSP) headers and additional security measures. If the sandbox proxy is served from the same origin as your host app, avoid combining `allow-scripts` with `allow-same-origin` for untrusted MCP app HTML; use `sandbox.permissions` to override the iframe sandbox attribute or serve the proxy from a dedicated, cookieless sandbox origin. See [@modelcontextprotocol/ext-apps](https://github.com/modelcontextprotocol/ext-apps) for more details on secure sandbox proxy implementation.
 :::
 
 ## 4. Create an MCP Client

--- a/docs/src/guide/mcp-apps.md
+++ b/docs/src/guide/mcp-apps.md
@@ -508,7 +508,6 @@ function ToolUI({ client, toolName, toolInput, toolResult }) {
 - `sendPromptListChanged()` - Notify guest when prompts change
 - `teardownResource()` - Clean up before unmounting
 
-<<<<<<< copilot/add-hostinfo-hostcapabilities-props
 ### Customizing Host Identity
 
 By default, `AppRenderer` identifies itself as "MCP-UI Host" to guest apps. You can customize the host identity and capabilities to properly identify your application:
@@ -544,7 +543,7 @@ function ToolUI({ client, toolName }) {
 ```
 
 This allows guest apps to know they're running in your specific host application and what capabilities are available.
-=======
+
 ### Handling Custom Requests (`onFallbackRequest`)
 
 AppRenderer includes built-in handlers for standard MCP Apps methods (`tools/call`, `ui/message`, `ui/open-link`, etc.). The `onFallbackRequest` prop lets you handle **any JSON-RPC request that doesn't match a built-in handler**. This is useful for:
@@ -593,7 +592,6 @@ The `sendExperimentalRequest` helper sends a properly formatted JSON-RPC request
 ::: tip Method Naming Convention
 Use the `x/<namespace>/<action>` prefix for experimental methods (e.g., `x/clipboard/write`). Standard MCP methods not yet in the Apps spec (e.g., `sampling/createMessage`) should use their canonical method names. When an experimental method proves useful, it can be promoted to a standard method in the [ext-apps spec](https://github.com/modelcontextprotocol/ext-apps).
 :::
->>>>>>> main
 
 ### Using Without an MCP Client
 

--- a/sdks/typescript/client/src/components/AppFrame.tsx
+++ b/sdks/typescript/client/src/components/AppFrame.tsx
@@ -10,7 +10,7 @@ import {
   type McpUiAppCapabilities,
 } from '@modelcontextprotocol/ext-apps/app-bridge';
 
-import { setupSandboxProxyIframe } from '../utils/app-host-utils';
+import { setupSandboxProxyIframe, type SandboxCancelRef } from '../utils/app-host-utils';
 
 /**
  * Build sandbox URL with CSP query parameter for HTTP header-based CSP enforcement.
@@ -165,6 +165,11 @@ export const AppFrame = (props: AppFrameProps) => {
     setError(null);
 
     let mounted = true;
+    // cancelRef is populated synchronously inside setupSandboxProxyIframe's Promise
+    // constructor, before any async yield. This guarantees it is set by the time
+    // React Strict Mode fires the effect cleanup — allowing the orphaned timeout
+    // to be cleared even when cleanup runs before the awaited result resolves.
+    const cancelRef: SandboxCancelRef = {};
 
     const setup = async () => {
       try {
@@ -176,7 +181,7 @@ export const AppFrame = (props: AppFrameProps) => {
           currentAppBridgeRef.current = null;
         }
 
-        const { iframe, onReady } = await setupSandboxProxyIframe(sandboxUrl);
+        const { iframe, onReady } = await setupSandboxProxyIframe(sandboxUrl, cancelRef);
 
         if (!mounted) return;
 
@@ -237,6 +242,7 @@ export const AppFrame = (props: AppFrameProps) => {
 
     return () => {
       mounted = false;
+      cancelRef.cancel?.();
     };
   }, [sandbox.url, sandbox.csp, appBridge]);
 

--- a/sdks/typescript/client/src/components/AppFrame.tsx
+++ b/sdks/typescript/client/src/components/AppFrame.tsx
@@ -125,6 +125,8 @@ export const AppFrame = (props: AppFrameProps) => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   // Track the current sandbox URL to detect when it changes
   const currentSandboxUrlRef = useRef<string | null>(null);
+  // Track the current sandbox permissions to detect when they change
+  const currentSandboxPermissionsRef = useRef<string | undefined>(undefined);
   // Track the current appBridge to detect when it changes (for isolation)
   const currentAppBridgeRef = useRef<AppBridge | null>(null);
 
@@ -152,6 +154,7 @@ export const AppFrame = (props: AppFrameProps) => {
     // but ensures isolation when switching to a different app/resource (different appBridge)
     if (
       currentSandboxUrlRef.current === sandboxUrlString &&
+      currentSandboxPermissionsRef.current === sandbox.permissions &&
       currentAppBridgeRef.current === appBridge &&
       iframeRef.current
     ) {
@@ -178,15 +181,21 @@ export const AppFrame = (props: AppFrameProps) => {
           containerRef.current.removeChild(iframeRef.current);
           iframeRef.current = null;
           currentSandboxUrlRef.current = null;
+          currentSandboxPermissionsRef.current = undefined;
           currentAppBridgeRef.current = null;
         }
 
-        const { iframe, onReady } = await setupSandboxProxyIframe(sandboxUrl, cancelRef);
+        const { iframe, onReady } = await setupSandboxProxyIframe(
+          sandboxUrl,
+          cancelRef,
+          sandbox.permissions,
+        );
 
         if (!mounted) return;
 
         iframeRef.current = iframe;
         currentSandboxUrlRef.current = sandboxUrlString;
+        currentSandboxPermissionsRef.current = sandbox.permissions;
         currentAppBridgeRef.current = appBridge;
         if (containerRef.current) {
           containerRef.current.appendChild(iframe);
@@ -244,7 +253,7 @@ export const AppFrame = (props: AppFrameProps) => {
       mounted = false;
       cancelRef.cancel?.();
     };
-  }, [sandbox.url, sandbox.csp, appBridge]);
+  }, [sandbox.url, sandbox.csp, sandbox.permissions, appBridge]);
 
   // Effect 2: Send HTML to sandbox when bridge is connected
   useEffect(() => {

--- a/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
@@ -119,7 +119,10 @@ describe('<AppFrame />', () => {
     render(<AppFrame {...getPropsWithBridge()} />);
 
     await waitFor(() => {
-      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledWith(defaultProps.sandbox.url);
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledWith(
+        defaultProps.sandbox.url,
+        expect.any(Object),
+      );
     });
   });
 
@@ -279,6 +282,39 @@ describe('<AppFrame />', () => {
   });
 
   describe('lifecycle', () => {
+    it('should cancel sandbox timeout when effect cleanup fires before await resolves (StrictMode)', async () => {
+      // Simulate the cancelRef being populated synchronously (as the real impl does).
+      // Capture the cancelRef passed to setupSandboxProxyIframe and verify cancel() is
+      // called before the mock ever resolves — this is the Strict Mode timing scenario.
+      let capturedCancelRef: { cancel?: () => void } | undefined;
+      const cancelSpy = vi.fn();
+
+      vi.mocked(appHostUtils.setupSandboxProxyIframe).mockImplementation(
+        async (_url, cancelRef) => {
+          capturedCancelRef = cancelRef;
+          // Synchronously populate the cancelRef, mirroring the real implementation
+          if (cancelRef) {
+            cancelRef.cancel = cancelSpy;
+          }
+          // Return a promise that never resolves, simulating a slow sandbox
+          return new Promise(() => {});
+        },
+      );
+
+      const { unmount } = render(<AppFrame {...getPropsWithBridge()} />);
+
+      // Flush microtasks so the mock implementation runs
+      await act(async () => {});
+
+      expect(capturedCancelRef).toBeDefined();
+
+      // Unmount (simulates Strict Mode cleanup between effect invocations)
+      unmount();
+
+      // cancel() must have been called to clear the orphaned timeout
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('should preserve iframe across re-renders', async () => {
       const { rerender } = render(<AppFrame {...getPropsWithBridge()} />);
 
@@ -329,7 +365,10 @@ describe('<AppFrame />', () => {
       // Should call setupSandboxProxyIframe again with new URL
       await waitFor(() => {
         expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(2);
-        expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenLastCalledWith(newSandboxUrl);
+        expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenLastCalledWith(
+          newSandboxUrl,
+          expect.any(Object),
+        );
       });
     });
 

--- a/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
+++ b/sdks/typescript/client/src/components/__tests__/AppFrame.test.tsx
@@ -122,6 +122,27 @@ describe('<AppFrame />', () => {
       expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledWith(
         defaultProps.sandbox.url,
         expect.any(Object),
+        undefined,
+      );
+    });
+  });
+
+  it('should call setupSandboxProxyIframe with sandbox permissions', async () => {
+    const permissions = 'allow-scripts allow-forms';
+
+    render(
+      <AppFrame
+        {...getPropsWithBridge({
+          sandbox: { ...defaultProps.sandbox, permissions },
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledWith(
+        defaultProps.sandbox.url,
+        expect.any(Object),
+        permissions,
       );
     });
   });
@@ -368,6 +389,47 @@ describe('<AppFrame />', () => {
         expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenLastCalledWith(
           newSandboxUrl,
           expect.any(Object),
+          undefined,
+        );
+      });
+    });
+
+    it('should recreate iframe when sandbox permissions change', async () => {
+      const { rerender } = render(<AppFrame {...getPropsWithBridge()} />);
+
+      await act(() => {
+        onReadyResolve();
+      });
+
+      await act(() => {
+        registeredOninitialized?.();
+      });
+
+      expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(1);
+
+      const secondOnReadyPromise = new Promise<void>((resolve) => {
+        onReadyResolve = resolve;
+      });
+      vi.mocked(appHostUtils.setupSandboxProxyIframe).mockResolvedValue({
+        iframe: mockIframe as HTMLIFrameElement,
+        onReady: secondOnReadyPromise,
+      });
+
+      const permissions = 'allow-scripts allow-forms';
+      rerender(
+        <AppFrame
+          {...getPropsWithBridge({
+            sandbox: { ...defaultProps.sandbox, permissions },
+          })}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenCalledTimes(2);
+        expect(appHostUtils.setupSandboxProxyIframe).toHaveBeenLastCalledWith(
+          defaultProps.sandbox.url,
+          expect.any(Object),
+          permissions,
         );
       });
     });

--- a/sdks/typescript/client/src/utils/app-host-utils.test.ts
+++ b/sdks/typescript/client/src/utils/app-host-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { SANDBOX_PROXY_READY_METHOD } from '@modelcontextprotocol/ext-apps/app-bridge';
+
+import { setupSandboxProxyIframe, type SandboxCancelRef } from './app-host-utils';
+
+describe('setupSandboxProxyIframe', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects onReady when sandbox never becomes ready (timeout)', async () => {
+    const cancelRef: SandboxCancelRef = {};
+    const { onReady } = await setupSandboxProxyIframe(
+      new URL('https://example.com/proxy'),
+      cancelRef,
+    );
+
+    const assertion = expect(onReady).rejects.toThrow(
+      /Timed out waiting for sandbox proxy iframe to be ready/,
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+  });
+
+  it('resolves onReady when cancel is called before the sandbox handshake completes', async () => {
+    const cancelRef: SandboxCancelRef = {};
+    const { onReady } = await setupSandboxProxyIframe(
+      new URL('https://example.com/proxy'),
+      cancelRef,
+    );
+
+    expect(cancelRef.cancel).toBeTypeOf('function');
+    cancelRef.cancel!();
+
+    await expect(onReady).resolves.toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+  });
+
+  it('resolves onReady when the sandbox posts the ready message', async () => {
+    const { iframe, onReady } = await setupSandboxProxyIframe(new URL('https://example.com/proxy'));
+
+    // jsdom does not attach contentWindow to programmatic iframes; the handler matches
+    // event.source === iframe.contentWindow, so expose a stable mock window reference.
+    const sandboxWindow = {} as Window;
+    Object.defineProperty(iframe, 'contentWindow', {
+      get: () => sandboxWindow,
+      configurable: true,
+    });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: sandboxWindow,
+        data: { method: SANDBOX_PROXY_READY_METHOD },
+      }),
+    );
+
+    await expect(onReady).resolves.toBeUndefined();
+  });
+});

--- a/sdks/typescript/client/src/utils/app-host-utils.test.ts
+++ b/sdks/typescript/client/src/utils/app-host-utils.test.ts
@@ -62,4 +62,20 @@ describe('setupSandboxProxyIframe', () => {
 
     await expect(onReady).resolves.toBeUndefined();
   });
+
+  it('sets the default sandbox permissions', async () => {
+    const { iframe } = await setupSandboxProxyIframe(new URL('https://example.com/proxy'));
+
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-same-origin allow-forms');
+  });
+
+  it('sets custom sandbox permissions', async () => {
+    const { iframe } = await setupSandboxProxyIframe(
+      new URL('https://example.com/proxy'),
+      undefined,
+      'allow-scripts allow-forms',
+    );
+
+    expect(iframe.getAttribute('sandbox')).toBe('allow-scripts allow-forms');
+  });
 });

--- a/sdks/typescript/client/src/utils/app-host-utils.ts
+++ b/sdks/typescript/client/src/utils/app-host-utils.ts
@@ -7,7 +7,20 @@ import { type Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 const DEFAULT_SANDBOX_TIMEOUT_MS = 10000;
 
-export async function setupSandboxProxyIframe(sandboxProxyUrl: URL): Promise<{
+/**
+ * Mutable ref object that is populated synchronously inside the Promise constructor
+ * of setupSandboxProxyIframe, before the first async yield. This allows callers to
+ * cancel the pending timeout even if cleanup fires before the awaited result resolves
+ * (e.g. React Strict Mode double-invocation).
+ */
+export interface SandboxCancelRef {
+  cancel?: () => void;
+}
+
+export async function setupSandboxProxyIframe(
+  sandboxProxyUrl: URL,
+  cancelRef?: SandboxCancelRef,
+): Promise<{
   iframe: HTMLIFrameElement;
   onReady: Promise<void>;
 }> {
@@ -33,6 +46,19 @@ export async function setupSandboxProxyIframe(sandboxProxyUrl: URL): Promise<{
         reject(new Error('Timed out waiting for sandbox proxy iframe to be ready'));
       }
     }, DEFAULT_SANDBOX_TIMEOUT_MS);
+
+    // Populated synchronously (before any async yield) so the cleanup function
+    // returned from useEffect can always call cancelRef.cancel() — even when React
+    // Strict Mode fires cleanup before the awaited setupSandboxProxyIframe resolves.
+    if (cancelRef) {
+      cancelRef.cancel = () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeoutId);
+          cleanup();
+        }
+      };
+    }
 
     const messageListener = (event: MessageEvent) => {
       if (event.source === iframe.contentWindow) {

--- a/sdks/typescript/client/src/utils/app-host-utils.ts
+++ b/sdks/typescript/client/src/utils/app-host-utils.ts
@@ -8,10 +8,9 @@ import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 const DEFAULT_SANDBOX_TIMEOUT_MS = 10000;
 
 /**
- * Mutable ref object that is populated synchronously inside the Promise constructor
- * of setupSandboxProxyIframe, before the first async yield. This allows callers to
- * cancel the pending timeout even if cleanup fires before the awaited result resolves
- * (e.g. React Strict Mode double-invocation).
+ * Assigned synchronously inside the onReady executor so callers can invoke
+ * `cancel()` while still awaiting `setupSandboxProxyIframe` or `onReady`.
+ * Cancelling clears timers and listeners and resolves `onReady`.
  */
 export interface SandboxCancelRef {
   cancel?: () => void;
@@ -47,15 +46,13 @@ export async function setupSandboxProxyIframe(
       }
     }, DEFAULT_SANDBOX_TIMEOUT_MS);
 
-    // Populated synchronously (before any async yield) so the cleanup function
-    // returned from useEffect can always call cancelRef.cancel() — even when React
-    // Strict Mode fires cleanup before the awaited setupSandboxProxyIframe resolves.
     if (cancelRef) {
       cancelRef.cancel = () => {
         if (!settled) {
           settled = true;
           clearTimeout(timeoutId);
           cleanup();
+          resolve();
         }
       };
     }

--- a/sdks/typescript/client/src/utils/app-host-utils.ts
+++ b/sdks/typescript/client/src/utils/app-host-utils.ts
@@ -6,6 +6,7 @@ import {
 import { type Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { type Tool } from '@modelcontextprotocol/sdk/types.js';
 const DEFAULT_SANDBOX_TIMEOUT_MS = 10000;
+const DEFAULT_SANDBOX_PERMISSIONS = 'allow-scripts allow-same-origin allow-forms';
 
 /**
  * Assigned synchronously inside the onReady executor so callers can invoke
@@ -19,6 +20,7 @@ export interface SandboxCancelRef {
 export async function setupSandboxProxyIframe(
   sandboxProxyUrl: URL,
   cancelRef?: SandboxCancelRef,
+  sandboxPermissions = DEFAULT_SANDBOX_PERMISSIONS,
 ): Promise<{
   iframe: HTMLIFrameElement;
   onReady: Promise<void>;
@@ -28,7 +30,7 @@ export async function setupSandboxProxyIframe(
   iframe.style.height = '600px';
   iframe.style.border = 'none';
   iframe.style.backgroundColor = 'transparent';
-  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms');
+  iframe.setAttribute('sandbox', sandboxPermissions);
 
   const onReady = new Promise<void>((resolve, reject) => {
     let settled = false;


### PR DESCRIPTION
## TLDR

IMO defaulting to allow-same-origin is fine if you host your iframe on a separate, cookieless sandbox origin. The issue is when the sandbox proxy is served from the same origin as the host app: allow-scripts + allow-same-origin lets untrusted MCP app HTML execute with host-origin privileges. This change makes sandbox.permissions actually apply, so hosts can opt into stricter isolation, e.g. allow-scripts allow-forms, without forking the client.

## Summary
- Thread `sandbox.permissions` through `AppFrame` into the sandbox proxy iframe instead of always using the default sandbox attribute.
- Recreate the iframe when sandbox permissions change so browser sandbox policy updates are applied.
- Document the permissions override and production guidance for same-origin sandbox proxies.
- Remove stale merge-conflict markers in `mcp-apps.md` that broke docs builds.

After:
```ts
<AppRenderer
  client={client}
  toolName="my-tool"
  sandbox={{
    url: sandboxUrl,
    permissions: "allow-scripts allow-forms",
  }}
/>
```

Advantage: hosts can now remove allow-same-origin for same-origin sandbox proxies, so untrusted MCP app HTML can still run scripts but no longer gets the host app’s origin privileges.