### PR TITLE
Add repository, bugs and homepage metadata for npm packages

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -17,6 +17,15 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/client"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
+  "homepage": "https://mcpui.dev/guide/client/overview",
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^1.2.0",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/sdks/typescript/server/package.json
+++ b/sdks/typescript/server/package.json
@@ -17,6 +17,15 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/server"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
+  "homepage": "https://mcpui.dev/guide/server/typescript/overview",
   "devDependencies": {
     "@types/node": "^18.19.100",
     "@vitest/coverage-v8": "^1.0.0",


### PR DESCRIPTION
## Summary

- Add npm repository metadata for @mcp-ui/client
- Add npm bugs metadata for @mcp-ui/client
- Add npm homepage metadata for @mcp-ui/client
- Add npm repository metadata for @mcp-ui/server
- Add npm bugs metadata for @mcp-ui/server
- Add npm homepage metadata for @mcp-ui/server

## Validation

- npm pack --dry-run
- git diff --check