### PR TITLE
Add npm metadata for TypeScript packages

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -3,6 +3,15 @@
   "version": "7.1.1",
   "description": "mcp-ui Client SDK",
   "private": false,
+  "homepage": "https://mcpui.dev",
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/client"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/typescript/server/package.json
+++ b/sdks/typescript/server/package.json
@@ -3,6 +3,15 @@
   "version": "6.1.0",
   "private": false,
   "description": "mcp-ui Server SDK",
+  "homepage": "https://mcpui.dev",
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/server"
+  },
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- add homepage, bugs, and repository metadata for `@mcp-ui/client`
- add homepage, bugs, and repository metadata for `@mcp-ui/server`
- include package-specific `repository.directory` values for the monorepo layout

## Validation
- `node -e "for (const f of ['sdks/typescript/client/package.json','sdks/typescript/server/package.json']) { const p=require('./'+f); if (!p.homepage || !p.bugs?.url || !p.repository?.url || !p.repository?.directory) process.exit(1); console.log(JSON.stringify({name:p.name,homepage:p.homepage,bugs:p.bugs,repository:p.repository})) }"`
- `npm pack ./sdks/typescript/client --dry-run --json --ignore-scripts`
- `npm pack ./sdks/typescript/server --dry-run --json --ignore-scripts`
- `git diff --check`