### PR TITLE
chore: add homepage, repository and bugs metadata to SDKs

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -86,5 +86,14 @@
       ]
     ]
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/MCP-UI-Org/mcp-ui/tree/main/sdks/typescript/client#readme",
+  "repository": {
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/client",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
+  }
 }

--- a/sdks/typescript/server/package.json
+++ b/sdks/typescript/server/package.json
@@ -72,5 +72,14 @@
   "dependencies": {
     "@modelcontextprotocol/ext-apps": "^0.3.1",
     "@modelcontextprotocol/sdk": "^1.25.1"
+  },
+  "homepage": "https://github.com/MCP-UI-Org/mcp-ui/tree/main/sdks/typescript/server#readme",
+  "repository": {
+    "url": "git+https://github.com/MCP-UI-Org/mcp-ui.git",
+    "directory": "sdks/typescript/server",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/MCP-UI-Org/mcp-ui/issues"
   }
 }


### PR DESCRIPTION
This PR adds missing \homepage\, \epository\, and \ugs.url\ metadata to \@mcp-ui/client\ and \@mcp-ui/server\ manifests.

This follows the requirements identified in charles-microbounties#959.

Summary of changes:
- Added \homepage\ linking to package subdirectories.
- Added \epository\ with \directory\ field for monorepo support.
- Added \ugs.url\ linking to the main repository issue tracker.