### PR TITLE
docs: remove leftover merge conflict markers from MCP Apps guide

### DIFF
--- a/docs/src/guide/mcp-apps.md
+++ b/docs/src/guide/mcp-apps.md
@@ -508,7 +508,6 @@ function ToolUI({ client, toolName, toolInput, toolResult }) {
 - `sendPromptListChanged()` - Notify guest when prompts change
 - `teardownResource()` - Clean up before unmounting
 
-<<<<<<< copilot/add-hostinfo-hostcapabilities-props
 ### Customizing Host Identity
 
 By default, `AppRenderer` identifies itself as "MCP-UI Host" to guest apps. You can customize the host identity and capabilities to properly identify your application:
@@ -544,7 +543,7 @@ function ToolUI({ client, toolName }) {
 ```
 
 This allows guest apps to know they're running in your specific host application and what capabilities are available.
-=======
+
 ### Handling Custom Requests (`onFallbackRequest`)
 
 AppRenderer includes built-in handlers for standard MCP Apps methods (`tools/call`, `ui/message`, `ui/open-link`, etc.). The `onFallbackRequest` prop lets you handle **any JSON-RPC request that doesn't match a built-in handler**. This is useful for:
@@ -593,7 +592,6 @@ The `sendExperimentalRequest` helper sends a properly formatted JSON-RPC request
 ::: tip Method Naming Convention
 Use the `x/<namespace>/<action>` prefix for experimental methods (e.g., `x/clipboard/write`). Standard MCP methods not yet in the Apps spec (e.g., `sampling/createMessage`) should use their canonical method names. When an experimental method proves useful, it can be promoted to a standard method in the [ext-apps spec](https://github.com/modelcontextprotocol/ext-apps).
 :::
->>>>>>> main
 
 ### Using Without an MCP Client
 


### PR DESCRIPTION
## Summary

`docs/src/guide/mcp-apps.md` has raw git conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) committed on `main` — they slipped in with #179 and are currently rendered on the published docs page.

Both sides of the conflict are valid, non-overlapping sections:
- **Customizing Host Identity** (documents the `hostInfo` / `hostCapabilities` props added in #179)
- **Handling Custom Requests (`onFallbackRequest`)** (already linked from the Key Props list earlier in the page)

This PR keeps both sections and removes only the three marker lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)