### PR TITLE
fix: emit CJS build so require('@mcp-ui/client') exposes exports

### DIFF
--- a/sdks/typescript/client/package.json
+++ b/sdks/typescript/client/package.json
@@ -4,14 +4,14 @@
   "description": "mcp-ui Client SDK",
   "private": false,
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/sdks/typescript/client/vite.config.ts
+++ b/sdks/typescript/client/vite.config.ts
@@ -17,9 +17,12 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
       name: 'McpUiClient',
-      formats: ['es', 'umd'],
+      // cjs for Node require() compatibility ("type": "module" makes .js files
+      // ESM, so the UMD bundle at index.js is not requirable); umd kept for
+      // script-tag/CDN consumers
+      formats: ['es', 'cjs', 'umd'],
       fileName: (format) =>
-        `index.${format === 'es' ? 'mjs' : format === 'umd' ? 'js' : format + '.js'}`,
+        `index.${format === 'es' ? 'mjs' : format === 'cjs' ? 'cjs' : 'js'}`,
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
## Summary

`require('@mcp-ui/client')` returns an **empty object** — zero exports. Reproduces on published 7.1.1:

```js
const m = require('@mcp-ui/client');
Object.keys(m); // []
```

## Cause

`package.json` points `main` and `exports["."].require` at `dist/index.js`, which is a **UMD** bundle. But the package has `"type": "module"`, so Node parses any `.js` file as ESM. Parsed as ESM, the UMD wrapper's `typeof exports === 'object'` branch never fires and the file has no `export` statements — so `require()` silently resolves to an empty namespace.

## Fix

Mirror what `@mcp-ui/server` already does:
- Add `cjs` to the vite lib formats, emitting `dist/index.cjs`
- Point `main` and `exports["."].require` at `./dist/index.cjs`
- Keep the UMD bundle at `dist/index.js` unchanged, for script-tag/CDN consumers

## Verification

Packed the tarball and installed it in a clean project:
- `require('@mcp-ui/client')` → 10 exports incl. `AppRenderer` (was 0)
- `import('@mcp-ui/client')` → 10 exports (unchanged)
- Client test suite: 74/74 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)